### PR TITLE
Fixed a bug that logger is nil.

### DIFF
--- a/deadman.go
+++ b/deadman.go
@@ -67,6 +67,7 @@ func newDeadMan(pinger <-chan time.Time, interval time.Duration, notifier func()
 		interval: interval,
 		notifier: notifier,
 		closer:   make(chan struct{}),
+		logger:   logger,
 	}
 }
 


### PR DESCRIPTION
I found the following error when alertmanager was down.
```
$ go run .
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x13361e7]

goroutine 1 [running]:
github.com/shokada/deadman/vendor/github.com/go-kit/kit/log.(*context).Log(0xc00009f950, 0xc00000eaa0, 0x2, 0x2, 0x2, 0x159ba60)
        /Users/JP26595/go/src/github.com/shokada/deadman/vendor/github.com/go-kit/kit/log/log.go:124 +0x207
main.(*Deadman).Run(0xc0000f1f18, 0x0, 0xc00016e060)
        /Users/JP26595/go/src/github.com/shokada/deadman/deadman.go:87 +0x2e6
main.main()
        /Users/JP26595/go/src/github.com/shokada/deadman/main.go:57 +0x854
exit status 2
```

To avoid this, I create this PR.

Thanks.